### PR TITLE
Use correct time layout

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func storeGyazoID(id string) error {
 
 	_, err = os.Stat(path)
 	if err == nil {
-		newpath := fmt.Sprintf("%s_%s.bak", id, time.Now().Format("20060102150406"))
+		newpath := fmt.Sprintf("%s_%s.bak", id, time.Now().Format("20060102150405"))
 		err = os.Rename(path, newpath)
 		if err != nil {
 			return err


### PR DESCRIPTION
Hi @Tomohiro 

I altered time layout at seconds.

``` go
package main

import (
    "fmt"
    "time"
)

func main() {
    fmt.Println(time.Now())
    fmt.Println(time.Now().Format("20060102150406")) // before
    fmt.Println(time.Now().Format("20060102150405")) // after
}

// Output
// 2014-09-09 20:36:51.206140293 +0900 JST
// 20140909203614 // <- at the end 14 is wrong (14 is "2014")
// 20140909203651 // <- at the end 51 is correct!!
```
