### PR TITLE
Support linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 
 ### Take a screenshot and then upload
 
-NOTE: this feature is available on OS X only.
+NOTE: this feature is not available on Windows(Imagemagick is required on Linux).
 
 ```sh
 $ gyazo

--- a/main.go
+++ b/main.go
@@ -154,6 +154,11 @@ func takeScreenshot() (string, error) {
 	case "darwin":
 		err = exec.Command("screencapture", "-i", path).Run()
 	case "linux":
+		area, err := selectArea()
+		if err != nil {
+			return "", err
+		}
+		err = exec.Command("import", "-window", "root", "-crop", area, path).Run()
 	case "windows":
 		err = errors.New("unsupported os")
 	}

--- a/select_area.go
+++ b/select_area.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+)
+
+func selectArea() (string, error) {
+	return "", fmt.Errorf(`selectArea is not supported other than Linux`)
+}

--- a/select_area_linux.go
+++ b/select_area_linux.go
@@ -1,0 +1,116 @@
+// +build linux
+
+package main
+
+/*
+#cgo LDFLAGS: -lX11
+#include <X11/Xlib.h>
+#include <X11/cursorfont.h>
+
+struct rectangle {
+	int x;
+	int y;
+	int width;
+	int height;
+};
+
+static int select_region(struct rectangle *rect)
+{
+	Display *dpy = XOpenDisplay(NULL);
+	Window root = DefaultRootWindow(dpy);
+	XEvent ev;
+
+	GC sel_gc;
+	XGCValues sel_gv;
+
+	int done = 0, btn_pressed = 0;
+	int x = 0, y = 0;
+	unsigned int width = 0, height = 0;
+	int start_x = 0, start_y = 0;
+
+	Cursor cursor = XCreateFontCursor(dpy, XC_crosshair);
+
+	XGrabPointer(dpy, root, True, (PointerMotionMask|ButtonPressMask|ButtonReleaseMask),
+		     GrabModeAsync, GrabModeAsync, None, cursor, CurrentTime);
+
+	sel_gv.function = GXinvert;
+	sel_gv.subwindow_mode = IncludeInferiors;
+	sel_gv.line_width = 1;
+	sel_gc = XCreateGC(dpy, root, (GCFunction|GCSubwindowMode|GCLineWidth), &sel_gv);
+
+	for (;;) {
+		XNextEvent(dpy, &ev);
+		switch (ev.type) {
+		case ButtonPress:
+			btn_pressed = 1;
+			x = start_x = ev.xbutton.x_root;
+			y = start_y = ev.xbutton.y_root;
+			width = height = 0;
+			break;
+		case MotionNotify:
+			if (btn_pressed) {
+				XDrawRectangle(dpy, root, sel_gc, x, y, width, height);
+
+				x = ev.xbutton.x_root;
+				y = ev.xbutton.y_root;
+
+				if (x > start_x) {
+					width = x - start_x;
+					x = start_x;
+				} else {
+					width = start_x - x;
+				}
+				if (y > start_y) {
+					height = y - start_y;
+					y = start_y;
+				} else {
+					height = start_y - y;
+				}
+
+				XDrawRectangle(dpy, root, sel_gc, x, y, width, height);
+				XFlush(dpy);
+			}
+			break;
+		case ButtonRelease:
+			done = 1;
+			break;
+		default:
+			break;
+		}
+		if (done)
+			break;
+	}
+
+	XDrawRectangle(dpy, root, sel_gc, x, y, width, height);
+	XFlush(dpy);
+
+	XUngrabPointer(dpy, CurrentTime);
+	XFreeCursor(dpy, cursor);
+	XFreeGC(dpy, sel_gc);
+	XSync(dpy, 1);
+
+	rect->x = x;
+	rect->y = y;
+	rect->width = width;
+	rect->height = height;
+
+	return 0;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func selectArea() (string, error) {
+	var area C.struct_rectangle
+
+	ret := int(C.select_region((*C.struct_rectangle)(unsafe.Pointer(&area))))
+	if ret != 0 {
+		return "", fmt.Errorf("Failed: selecting window")
+	}
+
+	return fmt.Sprintf("%dx%d+%d+%d", area.width, area.height, area.x, area.y), nil
+}


### PR DESCRIPTION
Demo is here(Ubuntu 15.04 xfce4). It is not easy to support all Linux platforms because Linux Desktop environments(GNOME, KDE etc) have own screenshot commands.  So I decided to use `import` command of ImageMagick command line utility and X11 library(`cgo`) for selecting area.

![output](https://cloud.githubusercontent.com/assets/554281/9898551/209d804a-5c8e-11e5-9641-bf5d6531638e.gif)
