### PR TITLE
Use `go build` instead of `go install` to install specify bindir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ setup:
 
 install: deps
 	@echo "===> Installing '$(OUTPUT)' to $(GOPATH)/bin..."
-	go build -o $(OUTPUT)
-	mv $(OUTPUT) $(GOPATH)/bin/
+	go build -o $(GOPATH)/bin/$(OUTPUT)
 
 deps:
 	@echo "===> Installing runtime dependencies..."


### PR DESCRIPTION
Relates https://github.com/Tomohiro/gyazo-cli/issues/10